### PR TITLE
more noise options, fixed schema compatibility

### DIFF
--- a/docs/L1_to_L2_README.rst
+++ b/docs/L1_to_L2_README.rst
@@ -82,6 +82,8 @@ The configuration is a Python dictionary (normally read from a YAML file).
 
 - ``SKYORDER``: If provided, then subtracts a median-based sky model that is a 2D polynomial of the given order.
 
+- ``NOISE_PRECISION``: The precision to store noise fields, as number of bits in IEEE 754 floating point convention. Options are 16 and 32 (default = 32).
+
 A sample file would be::
 
     ---
@@ -215,7 +217,11 @@ The types of commands are:
 
   The noise can be clipped based on the median and interquartile range at some number of equivalent sigmas with the 'z' directive, e.g., ``'Raz4.5'`` will clip at 4.5 sigma. This is useful if you want to be able to feed another noise layer through the pipeline without re-computing the outlier mask, and thus it is recommended for use with feeding noise realizations to PyIMCOM, etc.
 
-* ``P``: Under construction (will generate simulated Poisson noise)
+* ``P``: Generate Poisson noise. This must come after ``R`` (if present). The variants of this command that are currently supported are:
+
+  * ``Pbr`` : re-sampled Poisson noise with background (sky level) only.
+
+  * ``Pr`` : re-sampled Poisson noise including sources as well as background (i.e., "total" Poisson noise).
 
 * ``S``: Perform sky subtraction on the noise realizations of the given order, e.g., ``'S2'`` removes a 2nd order polynomial from the noise realization, ``'S0'`` removes a constant, etc.
 

--- a/runs/summer2025run/OpenUniverse_to_L1L2.job
+++ b/runs/summer2025run/OpenUniverse_to_L1L2.job
@@ -12,8 +12,8 @@
 
 cd $SLURM_SUBMIT_DIR
 python3 -m OpenUniverse_to_L1L2 \
-   --in=/fs/scratch/PCON0003/cond0007/anl-run-in-prod/truth/ \
-   --out=/fs/scratch/PCON0003/cond0007/summer2025/ \
+   --in=/fs/scratch/PCON0003/cond0007/fall2025/truth/ \
+   --out=/fs/scratch/PCON0003/cond0007/fall2025/sim/ \
    --cal=/fs/scratch/PCON0003/cond0007/cal/ \
    --tag=DUMMY20250521 --seed=500 --dseed=10 \
    --sca=$SLURM_ARRAY_TASK_ID > simprocess-$SLURM_ARRAY_TASK_ID.log

--- a/runs/summer2025run/OpenUniverse_to_L1L2.py
+++ b/runs/summer2025run/OpenUniverse_to_L1L2.py
@@ -121,7 +121,7 @@ for infile in os.listdir(input_dir):
         "SKYORDER": 2,
         "FITSOUT": sca == 4,  # save SCA #4.
         "NOISE": {
-            "LAYER": ["Rz4S2C1", "Rz4S2C2", "Rz4PbrS2", "Rz4PrS2"],
+            "LAYER": ["Rz4PbrS2C1", "Rz4PbrS2C2", "Rz4PrS2C3", "Rz4PrS2C4"],
             "TEMP": temp_dir + f"/temp_{band:s}_{obsid:d}_{sca:d}.asdf",
             "SEED": seed,
             "OUT": output_dir + f"/L2/sim_L2_{band:s}_{obsid:d}_{sca:d}_noise.asdf",

--- a/src/romanimpreprocess/L1_to_L2/gen_noise_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_noise_image.py
@@ -310,6 +310,12 @@ def generate_all_noise(config):
     for q in [5, 25, 50, 75, 95]:
         print(q, np.percentile(noiseimage, q, axis=(1, 2)))
 
+    if "NOISE_PRECISION" in config:
+        if config["NOISE_PRECISION"] == 16:
+            noiseimage = noiseimage.astype(np.float16)
+        if config["NOISE_PRECISION"] not in [16, 32]:
+            raise ValueError("Unsupported noise precision.")
+
     # now output the noise image
     tree = {"config": config, "noise": noiseimage}
     with asdf.AsdfFile(tree) as af, open(config["NOISE"]["OUT"], "wb") as f:

--- a/src/romanimpreprocess/from_sim/sim_to_isim.py
+++ b/src/romanimpreprocess/from_sim/sim_to_isim.py
@@ -540,8 +540,9 @@ class Image2D:
 
         target_pattern = 1000000
         parameters.read_pattern[target_pattern] = use_read_pattern
+        bandpass_name = "F" + self.filter[1:]  # schema wants, e.g., "F129" instead of "J129"
         metadata = ris.set_metadata(
-            date=self.date, bandpass=self.filter, sca=self.idsca[1], ma_table_number=target_pattern
+            date=self.date, bandpass=bandpass_name, sca=self.idsca[1], ma_table_number=target_pattern
         )
 
         print("::", self.ra_, self.dec_, self.pa_)


### PR DESCRIPTION
Added "forward-simulated" Poisson noise options. Also fixed filter name compatibility: the SOC schema wants, e.g., "F129" instead of the "J129" used in PIT processing.