### PR TITLE
Fix wfi_parallel flag handling in typefix.py

### DIFF
--- a/src/romanimpreprocess/utils/typefix.py
+++ b/src/romanimpreprocess/utils/typefix.py
@@ -30,9 +30,9 @@ def fix(tree):
     if "dummyfields" in tree["roman"]["meta"]:
         print("added dummy fields:", tree["roman"]["meta"]["dummyfields"])
 
-    # Fixing error that occurs with wfi parallel flag when using new roman datamodels with new utilities 
-    if "wfi_parallel" not in tree["roman"]["meta"]:
-        tree["roman"]["meta"]["wfi_parallel"] = False
+    # Fixing error that occurs with wfi parallel flag when using new roman datamodels with new utilities
+    if "wfi_parallel" not in tree["roman"]["meta"]["observation"]:
+        tree["roman"]["meta"]["observation"]["wfi_parallel"] = False
 
     # Which fields to check in "roman"
     changetypes = {"err": "float16", "var_poisson": "float16", "var_rnoise": "float16", "var_flat": "float16"}

--- a/src/romanimpreprocess/utils/typefix.py
+++ b/src/romanimpreprocess/utils/typefix.py
@@ -30,6 +30,10 @@ def fix(tree):
     if "dummyfields" in tree["roman"]["meta"]:
         print("added dummy fields:", tree["roman"]["meta"]["dummyfields"])
 
+    # Fixing error that occurs with wfi parallel flag when using new roman datamodels with new utilities 
+    if "wfi_parallel" not in tree["roman"]["meta"]:
+        tree["roman"]["meta"]["wfi_parallel"] = False
+
     # Which fields to check in "roman"
     changetypes = {"err": "float16", "var_poisson": "float16", "var_rnoise": "float16", "var_flat": "float16"}
 

--- a/src/romanimpreprocess/utils/typefix.py
+++ b/src/romanimpreprocess/utils/typefix.py
@@ -34,7 +34,8 @@ def fix(tree):
     if "wfi_parallel" not in tree["roman"]["meta"]["observation"]:
         tree["roman"]["meta"]["observation"]["wfi_parallel"] = False
 
-    # Fixing error for darkdecay, inverse linearity, and integral nonlinearity validation flag with using roman datamodels with new utilities
+    # Fixing error for darkdecay, inverse linearity, and integral nonlinearity validation flag with using
+    # roman_datamodels with new utilities
     data_names = ["darkdecaysignal", "inverselinearity", "integralnonlinearity"]
     for nameid in data_names:
         if nameid not in tree["roman"]["meta"]["ref_file"]:

--- a/src/romanimpreprocess/utils/typefix.py
+++ b/src/romanimpreprocess/utils/typefix.py
@@ -34,6 +34,10 @@ def fix(tree):
     if "wfi_parallel" not in tree["roman"]["meta"]["observation"]:
         tree["roman"]["meta"]["observation"]["wfi_parallel"] = False
 
+    # Fixing error for dark decay validation flag with using roman datamodels with new utilities
+    if "darkdecaysignal" not in tree["roman"]["meta"]["ref_file"]:
+        tree["roman"]["meta"]["ref_file"]["darkdecaysignal"] = "?"
+
     # Which fields to check in "roman"
     changetypes = {"err": "float16", "var_poisson": "float16", "var_rnoise": "float16", "var_flat": "float16"}
 

--- a/src/romanimpreprocess/utils/typefix.py
+++ b/src/romanimpreprocess/utils/typefix.py
@@ -34,9 +34,11 @@ def fix(tree):
     if "wfi_parallel" not in tree["roman"]["meta"]["observation"]:
         tree["roman"]["meta"]["observation"]["wfi_parallel"] = False
 
-    # Fixing error for dark decay validation flag with using roman datamodels with new utilities
-    if "darkdecaysignal" not in tree["roman"]["meta"]["ref_file"]:
-        tree["roman"]["meta"]["ref_file"]["darkdecaysignal"] = "?"
+    # Fixing error for darkdecay, inverse linearity, and integral nonlinearity validation flag with using roman datamodels with new utilities
+    data_names = ["darkdecaysignal", "inverselinearity", "integralnonlinearity"]
+    for nameid in data_names:
+        if nameid not in tree["roman"]["meta"]["ref_file"]:
+            tree["roman"]["meta"]["ref_file"][nameid] = "?"
 
     # Which fields to check in "roman"
     changetypes = {"err": "float16", "var_poisson": "float16", "var_rnoise": "float16", "var_flat": "float16"}


### PR DESCRIPTION
Add check for 'wfi_parallel' in roman metadata to prevent schema invalidation errors.