### PR TITLE
Make back up one step in saturation flagging optional

### DIFF
--- a/docs/L1_to_L2_README.rst
+++ b/docs/L1_to_L2_README.rst
@@ -84,6 +84,8 @@ The configuration is a Python dictionary (normally read from a YAML file).
 
 - ``NOISE_PRECISION``: The precision to store noise fields, as number of bits in IEEE 754 floating point convention. Options are 16 and 32 (default = 32).
 
+- ``SATURATION_BACKUP``: The number of frames to "back up" when checking for saturation. This will probably be 0 (SOC) or 1 (PIT) though any int is valid. The frame backup parameter defaults to 1 in the saturation check if not included here.
+
 A sample file would be::
 
     ---

--- a/docs/L1_to_L2_README.rst
+++ b/docs/L1_to_L2_README.rst
@@ -84,7 +84,7 @@ The configuration is a Python dictionary (normally read from a YAML file).
 
 - ``NOISE_PRECISION``: The precision to store noise fields, as number of bits in IEEE 754 floating point convention. Options are 16 and 32 (default = 32).
 
-- ``SATURATION_BACKUP``: The number of frames to "back up" when checking for saturation. This will probably be 0 (SOC) or 1 (PIT) though any int is valid. The frame backup parameter defaults to 1 in the saturation check if not included here.
+- ``SATURATION_BACKUP``: The number of frames to "back up" when checking for saturation. This will probably be 0 (SOC) or 1 (PIT) though any non-negative integer is valid. The frame backup parameter defaults to 1 in the saturation check if not included here.
 
 A sample file would be::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,8 @@ readme = "README.rst"
 authors = [
     { name = "Christopher M. Hirata", email = "hirata.10@osu.edu" },
     { name = "Katherine Laliotis", email = "laliotis.2@osu.edu" },
-    { name = "Michael Gabe", email = "gabe.7@osu.edu" }
+    { name = "Michael Gabe", email = "gabe.7@osu.edu" },
+    { name = "Eddie Schlafly", email = "eschlafly@stsci.edu" }
 ]
 maintainers = [
     { name = "Roman High Latitude Imaging Survey Cosmology Project Infrastructure Team" }

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -200,7 +200,7 @@ def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog, backup):
         Processing log.
     backup : int
         Number of frames to "back up" when checking saturation.
-        This is read from config["SATBACKUP"]. It defaults to 1
+        This is read from config["SATURATION_BACKUP"]. It defaults to 1
         if the keyword is not included in the config.
 
     Returns
@@ -357,7 +357,7 @@ def calibrateimage(config, verbose=True):
     # in some simulations we may need to give this if the input stars themselves are simulated
     thewcs = wcs_from_config(config)
     caldir = config["CALDIR"]
-    backup = config["SATBACKUP"] if "SATBACKUP" in config else 1
+    backup = config["SATURATION_BACKUP"] if "SATURATION_BACKUP" in config else 1
 
     # initialize a data cube and data quality
     data, rdq, pdq, meta, l1meta, amp33 = initializationstep(config, caldir, mylog)

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -357,7 +357,7 @@ def calibrateimage(config, verbose=True):
     # in some simulations we may need to give this if the input stars themselves are simulated
     thewcs = wcs_from_config(config)
     caldir = config["CALDIR"]
-    backup = config["SATURATION_BACKUP"] if "SATURATION_BACKUP" in config else 1
+    backup = config.get("SATURATION_BACKUP", 1)
 
     # initialize a data cube and data quality
     data, rdq, pdq, meta, l1meta, amp33 = initializationstep(config, caldir, mylog)

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -175,7 +175,7 @@ def initializationstep(config, caldir, mylog):
     return data, rdq, pdq, meta, l1meta, amp33
 
 
-def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog):
+def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog, backup):
     """
     Flags saturated pixels (in both 3D and 2D arrays).
 
@@ -198,6 +198,10 @@ def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog):
         Locations of calibration files.
     mylog : romanimpreprocess.utils.processlog.ProcessLog
         Processing log.
+    backup : int
+        Number of frames to "back up" when checking saturation.
+        This is read from config["SATBACKUP"]. It defaults to 1
+        if the keyword is not included in the config.
 
     Returns
     -------
@@ -229,7 +233,7 @@ def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog):
     # backs up 1 frame to be safe since if the non-linearity curve is sharp enough
     # the existing algorithm can fail on a large group
     # important to run this in ascending order
-    for i in range(len(read_pattern) - 1):
+    for i in range(len(read_pattern) - backup):
         if len(read_pattern[i]) > 1:
             rdq[i, :, :] |= rdq[i + 1, :, :] & pixel.SATURATED
 
@@ -353,6 +357,7 @@ def calibrateimage(config, verbose=True):
     # in some simulations we may need to give this if the input stars themselves are simulated
     thewcs = wcs_from_config(config)
     caldir = config["CALDIR"]
+    backup = config["SATBACKUP"] if "SATBACKUP" in config else 1
 
     # initialize a data cube and data quality
     data, rdq, pdq, meta, l1meta, amp33 = initializationstep(config, caldir, mylog)
@@ -361,7 +366,7 @@ def calibrateimage(config, verbose=True):
     mylog.append("Initialized data\n")
 
     # saturation check
-    saturation_check(data, meta["read_pattern"], rdq, pdq, caldir, mylog)
+    saturation_check(data, meta["read_pattern"], rdq, pdq, caldir, mylog, backup)
     mylog.append("Saturation check complete\n")
 
     # reference pixel correction -- right now using a 5-pixel filter of the left & right ref pixels

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -233,9 +233,10 @@ def saturation_check(data, read_pattern, rdq, pdq, caldir, mylog, backup):
     # backs up 1 frame to be safe since if the non-linearity curve is sharp enough
     # the existing algorithm can fail on a large group
     # important to run this in ascending order
-    for i in range(len(read_pattern) - backup):
-        if len(read_pattern[i]) > 1:
-            rdq[i, :, :] |= rdq[i + 1, :, :] & pixel.SATURATED
+    for _ in range(backup):
+        for i in range(len(read_pattern) - 1):
+            if len(read_pattern[i]) > 1:
+                rdq[i, :, :] |= rdq[i + 1, :, :] & pixel.SATURATED
 
 
 def subtract_dark_current(data, rdq, pdq, caldir, meta, mylog):


### PR DESCRIPTION
Addressing Issue #30 : 

Added a `backup` parameter into `romanimpreprocess.L1_to_L2.gen_cal_image.saturation_check` to specify the number of resultant images to step backwards from what the algorithm thinks is saturated.

When the check is called in `romanimpreprocess.L1_to_L2.gen_cal_image.calibrate_image`, the code now checks for a keyword `SATURATION_BACKUP` in the config YAML. The value in this keyword should be set to 0 for SOC-like processing. If the keyword is not included, the default value for the `backup` param inside `saturation_check` is 1.

Also added a description of this keyword into the` L1_to_L2` README. 