### PR TITLE
update reference pixel treatment

### DIFF
--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -330,8 +330,9 @@ def calibrateimage(config, verbose=True):
     # reference pixel correction -- right now using a 5-pixel filter of the left & right ref pixels
     # and the top & bottom pixel subtraction functions from Laliotis et al. (2024)
     # **This is a placeholder until:
-    #  - amp33 to be implemented (currently the simulation leaves it blank)
     #  - improved reference pixel correction from GSFC group should be available
+    #
+    slope = None  # will overwrite later
     with asdf.open(caldir["dark"]) as f:
         # rsub = np.zeros((ngrp, pars.nside), dtype=np.float32)
         for j in range(ngrp):
@@ -341,7 +342,21 @@ def calibrateimage(config, verbose=True):
                 if "amp33" in fr["roman"]:
                     image[:, -pars.channelwidth :] = amp33[j, :, :] - fr["roman"]["amp33"]["med"]
                     image[:, -pars.channelwidth :] -= np.median(image[:, -pars.channelwidth :])
-            image = reference_subtraction.ref_subtraction_row(image, use_ref_channel=True)
+
+                    # compute optimal slope, but only once
+                    if slope is None:
+                        a = fr["roman"]["amp33"]
+                        cvar = fr["roman"]["anc"]["C_PINK"] ** 2
+                        slope = (
+                            a["M_PINK"]
+                            * cvar
+                            / (
+                                a["M_PINK"] ** 2 * cvar
+                                + a["RU_PINK"] ** 2
+                                + np.median(a["std"]) ** 2 / 128 / np.log(4096)
+                            )
+                        )
+            image = reference_subtraction.ref_subtraction_row(image, use_ref_channel=True, slope=slope)
             image = reference_subtraction.ref_subtraction_channel(image, use_ref_channel=True)
             data[j, :, :] = image[:, : pars.nside] + f["roman"]["data"][j, :, :]
 

--- a/src/romanimpreprocess/utils/reference_subtraction.py
+++ b/src/romanimpreprocess/utils/reference_subtraction.py
@@ -74,7 +74,7 @@ def ref_subtraction_channel(image, channel_start=0, channel_end=128, use_ref_cha
     return image
 
 
-def ref_subtraction_row(image, use_ref_channel=False):
+def ref_subtraction_row(image, use_ref_channel=False, slope=None):
     """
     Row-based reference subtraction.
 
@@ -90,6 +90,9 @@ def ref_subtraction_row(image, use_ref_channel=False):
         A 2D numpy array representing the slopes image.
     use_ref_channel : bool, optional
         Whether to use the reference output for fitting.
+    slope : float, optional
+        The multiplying factor by the reference to subtract from the data.
+        If None, then does a fit to determine the best slope.
 
     Returns
     -------
@@ -101,21 +104,22 @@ def ref_subtraction_row(image, use_ref_channel=False):
     sci_medians = []
     ref_medians = []
     for row in range(0, 4096):
-        sci_medians.append(np.median(image[row, 4:4088]))
+        sci_medians.append(np.median(image[row, 4:4092]))
         if use_ref_channel:
             ref_medians.append(np.median(image[row, 4096:4224]))
         else:
-            ref_medians.append(np.median(np.hstack((image[row, 0:4], image[row, 4088:4096]))))
+            ref_medians.append(np.median(np.hstack((image[row, 0:4], image[row, 4092:4096]))))
+    ref_medians = np.array(ref_medians)
 
-    m_med, b_med = np.polyfit(ref_medians, sci_medians, 1)
+    m_med, _ = np.polyfit(ref_medians, sci_medians, 1)
+    ctr = np.median(ref_medians)
 
-    def med_func(i):
-        I_med = m_med * i + b_med
-        return I_med
+    # overwrite with provided slope if specified
+    if slope is not None:
+        m_med = slope
 
     # Iterate through all rows: compute median value, subtract it across the whole row
     for i in range(0, 4096):
-        I_med = med_func(ref_medians[i])
-        image[i, :] = image[i, :] - I_med
+        image[i, :] = image[i, :] - m_med * (ref_medians[i] - ctr)
 
     return image

--- a/tests/romanimpreprocess/test_ref.py
+++ b/tests/romanimpreprocess/test_ref.py
@@ -1,0 +1,21 @@
+"""An artificial case for reference subtraction."""
+
+import numpy as np
+from romanimpreprocess.utils.reference_subtraction import ref_subtraction_row
+
+
+def test_row():
+    """Tet for row-based reference subtraction without the use_ref_channel option."""
+
+    im = np.zeros((4096, 4224), dtype=np.float32)
+    im[:, :] = np.cos(np.linspace(0, 2000, 4096))[:, None]
+    im[:, -128:] *= 2.0
+    for x in range(4224):
+        im[:, x] += np.sin(0.1 * x) * np.sin(np.linspace(0, 2000, 4096)) ** 3
+    im[:, :-128] += 1.0
+    im_old = np.copy(im)
+
+    ref_subtraction_row(im, use_ref_channel=False)
+    assert np.std(im) < 0.75 * np.std(im_old)
+    assert 0.4 < np.std(im[:, :-128]) < 0.5
+    assert 0.99 < np.mean(im[:, :-128]) < 1.01

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -544,7 +544,7 @@ def test_run_all(tmp_path):
             count = np.count_nonzero(np.bitwise_and(a["roman"]["dq"] >> i, 1))
             print(f"BIT {i:2d} {count:7d}")
             if i == 2:
-                assert count > 10000 and count < 1500000  # this is way too many!
+                assert count > 10000 and count < 30000
         isGood = np.where(a["roman"]["dq"] == 0, 1, 0)
 
         # now pull out the data, in DN/s


### PR DESCRIPTION
Background
----------

In the previous unit test, the cosmic ray rejection flag was being set incorrectly in large "stripes" across the image (following the 1/f noise pattern). This didn't happen in the simulated science images, but it affects the unit test and @schlafly noticed it while working on merging with `romancal` functions.

After some investigation, it turned out this was because the previous reference pixel correction fit a coefficient from each resultant (after subtracting the dark image). This is normally fine when the reset level is near that in the dark image, but the unit test reset to a different level than the dark. The code *should* work in this case, but it was having a problem because of the chance correlation of the 1/f noise pattern with the difference between the reset level in the unit test and the level of the dark frame. The "bad" 1/f noise correction caused pixels in some rows to trigger the jump detection (which doesn't know about 1/f noise).

Solution
--------

I changed the row reference pixel correction to use the coefficient (slope of science image with respect to reference output) from the reference file instead of fitting each resultant. In addition:

- I did some light editing of @kklaliotis's code in the reference row.
- I set the intercept so the median correction is zero.
- I fixed a bug in column indexing (though in a branch of the code that wasn't being used).

Path forward
------------

Since this is a change to the algorithm, I'm going to rerun one mosaic through `romanimpreprocess` to make sure nothing weird happens before marking this PR as ready for review.