### PR TITLE
Add treatment of additional systematics and migrate some steps to romancal

### DIFF
--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -227,6 +227,10 @@ def subtract_dark_current(image_model, caldir, mylog):
         dark_current_step.subtract_dark_current(image_model, darkref)
         image_model.data = full_data
         image_model.dq = full_dq
+    # Note: we deliberately do not mark image_model.meta.cal_step.dark here.
+    # make_asdf rebuilds the output metadata and resets cal_step, so the marking
+    # would not reach the output; cal_step handling is deferred until that is
+    # reworked.
 
 
 def repackage_wcs(thewcs):
@@ -320,7 +324,7 @@ def correct_dark_decay(ramp_model, caldir, mylog):
     ramp_model.meta.cal_step.dark_decay = "COMPLETE"
 
 
-def correct_wfi18_transient(ramp_model, mylog, mask_rows=False):
+def correct_wfi18_transient(ramp_model, config, mylog):
     """
     Corrects the WFI18 first-read transient.
 
@@ -331,18 +335,18 @@ def correct_wfi18_transient(ramp_model, mylog, mask_rows=False):
     ----------
     ramp_model : roman_datamodels.datamodels.RampModel
         data model including resultant cube
+    config : dict
+        Configuration dictionary. If ``config["wfi18_mask_rows"]`` is True,
+        mask the most affected rows instead of fitting and removing the anomaly.
     mylog : romanimpreprocess.utils.processlog.ProcessLog
         Processing log.
-    mask_rows : bool
-        If True, mask the most affected rows instead of fitting and
-        removing the anomaly.
     """
 
     if ramp_model.meta.instrument.detector != "WFI18":
         mylog.append("Skipping WFI18 transient correction (not WFI18)\n")
         ramp_model.meta.cal_step.wfi18_transient = "N/A"
         return
-    correct_anomaly(ramp_model, mask_rows=mask_rows)
+    correct_anomaly(ramp_model, mask_rows=config.get("wfi18_mask_rows", False))
     mylog.append("WFI18 transient correction complete\n")
     ramp_model.meta.cal_step.wfi18_transient = "COMPLETE"
 
@@ -416,9 +420,9 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             gain = datamodels.GainRefModel.create_from_model(fg["roman"])
         # stcal's likelihood fitter treats the read-noise reference as CDS and
         # divides it by sqrt(2) internally; Roman read noise is single-read, so
-        # we multiply by sqrt(2) here to compensate. This is a stopgap: the plan
-        # is to handle the convention in romancal (likely_fit), after which this
-        # line should be removed.
+        # we multiply by sqrt(2) here to compensate. This is a stopgap pending
+        # romancal PR https://github.com/spacetelescope/romancal/pull/2360 --
+        # delete this line once that is merged.
         readnoise.data = (np.sqrt(2) * readnoise.data).astype('f4')
         # exclude_first handling is not required here, since these pixels
         # are marked DO_NOT_USE in the initializationstep
@@ -426,7 +430,6 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             ramp_model,
             readnoise,
             gain,
-            include_var_rnoise=True,
             rejection_threshold=config.get("REJECTION_THRESHOLD", 4.5),
             jump_kw=config.get("JUMP_KW", None),
         )
@@ -454,19 +457,17 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             mylog,
             exclude_first=exclude_first,
         )
-        # package into an ImageModel via the (private) romancal helper, which
-        # trims the reference border and returns the active region.
-        # TODO: replace _create_image_model with a public path.
+        # package result into an ImageModel using a romancal routine.
+        # That routine also trims the reference border and returns the
+        # active region.  Ideally I want to deprecate this path and so I'm
+        # using a private romancal routine for now.
         image_info = {
             "slope": slope,
             "dq": ramp_model.pixeldq,
             "err": np.hypot(slope_err_read, slope_err_poisson),
             "var_poisson": slope_err_poisson**2,
-            "var_rnoise": slope_err_read**2,
         }
-        image_model = ramp_fit_step._create_image_model(
-            ramp_model, image_info, include_var_rnoise=True
-        )
+        image_model = ramp_fit_step._create_image_model(ramp_model, image_info)
 
     # re-embed the active region into the full frame so the rest of the
     # pipeline stays full-frame. The science/variance border pixels are zeroed
@@ -474,7 +475,6 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
     # reference-pixel flags carried by ramp_model.pixeldq.
     image_model.data = _embed_active(image_model.data, nb)
     image_model.var_poisson = _embed_active(image_model.var_poisson, nb)
-    image_model.var_rnoise = _embed_active(image_model.var_rnoise, nb)
     image_model.err = _embed_active(image_model.err, nb)
     full_dq = np.array(ramp_model.pixeldq, dtype=np.uint32)
     full_dq[nb:-nb, nb:-nb] = image_model.dq
@@ -575,10 +575,7 @@ def calibrateimage(config, verbose=True):
         ramp_model.meta.cal_step.dark_decay = "INCOMPLETE"
 
     if config.get("correct_wfi18_transient", False):
-        # function marks the step "N/A" if not WFI18
-        correct_wfi18_transient(
-            ramp_model, mylog, mask_rows=config.get("WFI18_MASK_ROWS", False)
-        )
+        correct_wfi18_transient(ramp_model, config, mylog)
     else:
         ramp_model.meta.cal_step.wfi18_transient = "INCOMPLETE"
 
@@ -614,8 +611,11 @@ def calibrateimage(config, verbose=True):
     # unpack the rate image back into full-frame arrays for use downstream
     slope = np.asarray(image_model.data, dtype=np.float32)
     pdq = np.asarray(image_model.dq, dtype=np.uint32)
-    slope_err_read = np.sqrt(np.asarray(image_model.var_rnoise, dtype=np.float32))
+    # read-noise error is derived from the total err and the Poisson variance
+    # (the ramp fitter no longer exposes var_rnoise separately).
+    err = np.asarray(image_model.err, dtype=np.float32)
     slope_err_poisson = np.sqrt(np.asarray(image_model.var_poisson, dtype=np.float32))
+    slope_err_read = np.sqrt(np.clip(err**2 - slope_err_poisson**2, 0.0, None))
 
     # apply flat field
     flat = flatutils.get_flat(caldir, meta, pdq)

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -197,6 +197,10 @@ def subtract_dark_current(image_model, caldir, mylog):
     (4088x4088) rather than a full-frame 4096x4096 image, so there
     are some gymnastics to handle that difference.
 
+    dark subtraction occurs after IPC deconvolution, but the dark
+    reference file is IPC-convolved, so this routine also corrects
+    the dark reference file for IPC.
+
     Parameters
     ----------
     image_model : roman_datamodels.datamodels.ImageModel
@@ -210,6 +214,14 @@ def subtract_dark_current(image_model, caldir, mylog):
     nb = pars.nborder
     with asdf.open(caldir["dark"]) as f:
         darkref = datamodels.DarkRefModel.create_from_model(f["roman"])
+
+        # correct IPC in dark reference file
+        if "ipc4d" in caldir:
+            dslope = np.array(darkref.dark_slope, dtype=np.float32)[None, :, :]
+            ipc_linearity.correct_cube(dslope, caldir["ipc4d"], None, gain_file=caldir["gain"])
+            darkref.dark_slope = dslope[0]
+            mylog.append("IPC-corrected the dark slope\n")
+
         full_data = image_model.data
         full_dq = image_model.dq
         image_model.data = full_data[nb:-nb, nb:-nb]

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -87,7 +87,7 @@ def wcs_from_config(config):
     return None
 
 
-def initializationstep(config, caldir, mylog, exclude_first=False):
+def initializationstep(config, caldir, mylog):
     """
     Initialization step.
 
@@ -99,8 +99,6 @@ def initializationstep(config, caldir, mylog, exclude_first=False):
         Locations of calibration files.
     mylog : romanimpreprocess.utils.processlog.ProcessLog
         Processing log.
-    exclude_first : bool
-        if True, mark first resultant as DO_NOT_USE
 
     Returns
     -------
@@ -141,7 +139,7 @@ def initializationstep(config, caldir, mylog, exclude_first=False):
             "frame_time"
         ]
 
-    if exclude_first:
+    if config.get("EXCLUDE_FIRST", True):
         ramp_model["groupdq"][0, ...] |= group.DO_NOT_USE
 
     return ramp_model, meta
@@ -416,22 +414,30 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             readnoise = datamodels.ReadnoiseRefModel.create_from_model(fr["roman"])
         with asdf.open(caldir["gain"]) as fg:
             gain = datamodels.GainRefModel.create_from_model(fg["roman"])
+        # stcal's likelihood fitter treats the read-noise reference as
+        # CDS and divides it by sqrt(2) internally
+        # we multiply by sqrt(2) to convert to this convention.
+        readnoise.data = (np.sqrt(2) * readnoise.data).astype('f4')
+        # exclude_first handling is not required here, since these pixels
+        # are marked DO_NOT_USE in the initializationstep
         image_model = ramp_fit_step.likely(
             ramp_model,
             readnoise,
             gain,
             include_var_rnoise=True,
+            rejection_threshold=config.get("REJECTION_THRESHOLD", 4.5),
             jump_kw=config.get("JUMP_KW", None),
         )
         meta["K"] = None  # not used by the likelihood fitter
         meta["ramp_opt_pars"] = None  # likewise
         mylog.append("romancal likelihood ramp fit complete\n")
     else:
+        exclude_first = config.get("EXCLUDE_FIRST", True)
         uopt = {"slope": 0.4, "gain": 1.8, "sigma_read": 6.5}
         if "RAMP_OPT_PARS" in config:
             uopt = config["RAMP_OPT_PARS"]
         u_ = float(uopt["slope"]) / float(uopt["gain"]) / float(uopt["sigma_read"]) ** 2
-        meta["K"] = fitting.construct_weights(u_, meta, exclude_first=True)
+        meta["K"] = fitting.construct_weights(u_, meta, exclude_first=exclude_first)
         meta["ramp_opt_pars"] = uopt
         mylog.append(f"\n\nRamp fit optimized for u = {u_:11.5E} s**-1\n")
         mylog.append("weights = {}\n".format(meta["K"]))
@@ -444,7 +450,7 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             meta,
             caldir,
             mylog,
-            exclude_first=True,
+            exclude_first=exclude_first,
         )
         # package into an ImageModel via the (private) romancal helper, which
         # trims the reference border and returns the active region.
@@ -686,7 +692,7 @@ def calibrateimage(config, verbose=True):
         "weights": meta["K"],
         "config": config,
         "log": mylog.output,
-        "exclude_first": True,
+        "exclude_first": config.get("EXCLUDE_FIRST", True),
     }
 
     # this is for getting the ramp data so we know which range was used

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -421,8 +421,7 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
         # stcal's likelihood fitter treats the read-noise reference as CDS and
         # divides it by sqrt(2) internally; Roman read noise is single-read, so
         # we multiply by sqrt(2) here to compensate. This is a stopgap pending
-        # romancal PR https://github.com/spacetelescope/romancal/pull/2360 --
-        # delete this line once that is merged.
+        # romancal PR https://github.com/spacetelescope/romancal/pull/2360
         readnoise.data = (np.sqrt(2) * readnoise.data).astype('f4')
         # exclude_first handling is not required here, since these pixels
         # are marked DO_NOT_USE in the initializationstep

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -34,6 +34,10 @@ from roman_datamodels.dqflags import group, pixel
 from romancal.datamodels.fileio import open_dataset
 from romancal.dq_init import dq_initialization
 from romancal.saturation import saturation
+from romancal.dark_current import dark_current_step
+from romancal.dark_decay.dark_decay import subtract_dark_decay
+from romancal.ramp_fitting import ramp_fit_step
+from romancal.wfi18_transient.wfi18_transient import correct_anomaly
 from romanisim import image as rimage
 from romanisim import persistence as rip
 from romanisim import wcs as riwcs
@@ -165,10 +169,6 @@ def saturation_check(ramp_model, caldir, mylog, backup=1, skip_firstn=1):
     skip_firstn : int
         Do not check the first n resultants in ramp_model.data for saturation.
 
-    Returns
-    -------
-    None
-
     """
 
     with asdf.open(caldir["saturation"]) as satreffile:
@@ -187,40 +187,36 @@ def saturation_check(ramp_model, caldir, mylog, backup=1, skip_firstn=1):
             ramp_model.meta.exposure.read_pattern = old_read_pattern
 
 
-def subtract_dark_current(data, rdq, pdq, caldir, meta, mylog):
+def subtract_dark_current(image_model, caldir, mylog):
     """
-    Subtracts dark current from a linearized image.
+    Subtracts dark current from a rate image.
 
-    The `data`, `rdq`, and `pdq` fields are updated in place.
+    image_model is updated in place.
+
+    romancal expects to subtract from an active-region image only
+    (4088x4088) rather than a full-frame 4096x4096 image, so there
+    are some gymnastics to handle that difference.
 
     Parameters
     ----------
-    data : np.array
-        3D data cube (in DN_lin, shape ngroup,4096,4096)
-    rdq : np.array
-        3D ramp data quality (uint32, shape ngroup,4096,4096)
-    pdq : np.array
-        2D pixel data quality (uint32, shape 4096,4096)
+    image_model : roman_datamodels.datamodels.ImageModel
+        2D Roman image model (DN / s), full 4096x4096 frame.
     caldir : dict
         Locations of calibration files.
-    meta : dict
-        Metadata dictionary (from L1 ASDF tree).
     mylog : romanimpreprocess.utils.processlog.ProcessLog
         Processing log.
-
-    Returns
-    -------
-    np.array
-        The 2D image of subtracted dark current in DN/s.
-
     """
 
+    nb = pars.nborder
     with asdf.open(caldir["dark"]) as f:
-        dcsub = np.copy(f["roman"]["dark_slope"])
-    ngrp = meta["ngrp"]
-    for j in range(ngrp):
-        data[j, :, :] -= meta["tbar"][j] * dcsub
-    return dcsub
+        darkref = datamodels.DarkRefModel.create_from_model(f["roman"])
+        full_data = image_model.data
+        full_dq = image_model.dq
+        image_model.data = full_data[nb:-nb, nb:-nb]
+        image_model.dq = full_dq[nb:-nb, nb:-nb]
+        dark_current_step.subtract_dark_current(image_model, darkref)
+        image_model.data = full_data
+        image_model.dq = full_dq
 
 
 def repackage_wcs(thewcs):
@@ -280,6 +276,191 @@ def repackage_wcs(thewcs):
         #    raise Exception("Unrecognized WCS") from e
 
     return wcsobj
+
+
+def correct_dark_decay(ramp_model, caldir, mylog):
+    """
+    Subtracts the dark decay signal from a resultant cube.
+
+    ramp_model is updated in place.
+
+    Parameters
+    ----------
+    ramp_model : roman_datamodels.datamodels.RampModel
+        data model including resultant cube
+    caldir : dict
+        Locations of calibration files.
+    mylog : romanimpreprocess.utils.processlog.ProcessLog
+        Processing log.
+    """
+
+    detector = ramp_model.meta.instrument.detector
+    with asdf.open(caldir["dark_decay"]) as f:
+        decayref = datamodels.DarkdecaysignalRefModel.create_from_model(f["roman"])
+        decay_table = getattr(decayref.decay_table, detector)
+        subtract_dark_decay(
+            ramp_model.data,
+            decay_table.amplitude,
+            decay_table.time_constant,
+            ramp_model.meta.exposure.frame_time,
+            ramp_model.meta.exposure.read_pattern,
+            int(detector[3:]),
+        )
+    mylog.append("Dark decay correction complete\n")
+    ramp_model.meta.cal_step.dark_decay = "COMPLETE"
+
+
+def correct_wfi18_transient(ramp_model, mylog, mask_rows=False):
+    """
+    Corrects the WFI18 first-read transient.
+
+    Only applies to detector WFI18; for any other detector the model is
+    returned unchanged. The ramp_model is updated in place.
+
+    Parameters
+    ----------
+    ramp_model : roman_datamodels.datamodels.RampModel
+        data model including resultant cube
+    mylog : romanimpreprocess.utils.processlog.ProcessLog
+        Processing log.
+    mask_rows : bool
+        If True, mask the most affected rows instead of fitting and
+        removing the anomaly.
+    """
+
+    if ramp_model.meta.instrument.detector != "WFI18":
+        mylog.append("Skipping WFI18 transient correction (not WFI18)\n")
+        ramp_model.meta.cal_step.wfi18_transient = "N/A"
+        return
+    correct_anomaly(ramp_model, mask_rows=mask_rows)
+    mylog.append("WFI18 transient correction complete\n")
+    ramp_model.meta.cal_step.wfi18_transient = "COMPLETE"
+
+
+def _embed_active(active, nb=4):
+    """
+    Embeds the active region into a full region that includes border pixels.
+
+    Parameters
+    ----------
+    active : np.array
+        2D array covering the active 4088x4088 pixels only
+    nb : int
+        Number of reference-pixel border rows/columns, usually 4.
+
+    Returns
+    -------
+    np.array
+        Full-frame array with the border zeroed and the active region
+        filled. Returned as float32.
+
+    """
+
+    full = np.zeros(tuple(x + 2 * nb for x in active.shape), dtype=np.float32)
+    full[nb:-nb, nb:-nb] = active
+    return full
+
+
+def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
+    """
+    Fit a slope to a ramp model, returning a 2D rate ImageModel.
+
+    If config["romancal_ramp_fit"] is True, use the likelihood-based
+    ramp fitting approach taken in romancal; otherwise, use the specialized
+    ramp fitting approach from fitting.ramp_fit.
+
+    romancal expects to return 4088x4088 images (trimming the border pixels),
+    but this pipeline expects 4096x4096 full frame images.  We work around that
+    by reembedding the active region in the larger frame.  These pixels get
+    trimmed off anyway in the final image.
+
+    Parameters
+    ----------
+    ramp_model : roman_datamodels.datamodels.RampModel
+        Ramp data model holding the linearized cube, flags, and the
+        border-reference fields.
+    meta : dict
+        Metadata dictionary. ``meta["K"]`` (ramp weights) and
+        ``meta["ramp_opt_pars"]`` are set here for downstream bookkeeping.
+    config : dict
+        Configuration dictionary.
+    caldir : dict
+        Locations of calibration files.
+    mylog : romanimpreprocess.utils.processlog.ProcessLog
+        Processing log.
+
+    Returns
+    -------
+    roman_datamodels.datamodels.ImageModel
+        2D rate image (DN/s), full 4096x4096 frame.
+
+    """
+
+    nb = pars.nborder
+
+    if config.get("romancal_ramp_fit", False):
+        # romancal maximum-likelihood ramp fit
+        with asdf.open(caldir["read"]) as fr:
+            readnoise = datamodels.ReadnoiseRefModel.create_from_model(fr["roman"])
+        with asdf.open(caldir["gain"]) as fg:
+            gain = datamodels.GainRefModel.create_from_model(fg["roman"])
+        image_model = ramp_fit_step.likely(
+            ramp_model,
+            readnoise,
+            gain,
+            include_var_rnoise=True,
+            jump_kw=config.get("JUMP_KW", None),
+        )
+        meta["K"] = None  # not used by the likelihood fitter
+        meta["ramp_opt_pars"] = None  # likewise
+        mylog.append("romancal likelihood ramp fit complete\n")
+    else:
+        uopt = {"slope": 0.4, "gain": 1.8, "sigma_read": 6.5}
+        if "RAMP_OPT_PARS" in config:
+            uopt = config["RAMP_OPT_PARS"]
+        u_ = float(uopt["slope"]) / float(uopt["gain"]) / float(uopt["sigma_read"]) ** 2
+        meta["K"] = fitting.construct_weights(u_, meta, exclude_first=True)
+        meta["ramp_opt_pars"] = uopt
+        mylog.append(f"\n\nRamp fit optimized for u = {u_:11.5E} s**-1\n")
+        mylog.append("weights = {}\n".format(meta["K"]))
+        if "JUMP_DETECT_PARS" in config:
+            meta["jump_detect_pars"] = config["JUMP_DETECT_PARS"]
+        slope, slope_err_read, slope_err_poisson = fitting.ramp_fit(
+            ramp_model.data,
+            ramp_model.groupdq,
+            ramp_model.pixeldq,
+            meta,
+            caldir,
+            mylog,
+            exclude_first=True,
+        )
+        # package into an ImageModel via the (private) romancal helper, which
+        # trims the reference border and returns the active region.
+        # TODO: replace _create_image_model with a public path.
+        image_info = {
+            "slope": slope,
+            "dq": ramp_model.pixeldq,
+            "err": np.hypot(slope_err_read, slope_err_poisson),
+            "var_poisson": slope_err_poisson**2,
+            "var_rnoise": slope_err_read**2,
+        }
+        image_model = ramp_fit_step._create_image_model(
+            ramp_model, image_info, include_var_rnoise=True
+        )
+
+    # re-embed the active region into the full frame so the rest of the
+    # pipeline stays full-frame. The science/variance border pixels are zeroed
+    # (they are trimmed off the final product anyway); the border dq keeps the
+    # reference-pixel flags carried by ramp_model.pixeldq.
+    image_model.data = _embed_active(image_model.data, nb)
+    image_model.var_poisson = _embed_active(image_model.var_poisson, nb)
+    image_model.var_rnoise = _embed_active(image_model.var_rnoise, nb)
+    image_model.err = _embed_active(image_model.err, nb)
+    full_dq = np.array(ramp_model.pixeldq, dtype=np.uint32)
+    full_dq[nb:-nb, nb:-nb] = image_model.dq
+    image_model.dq = full_dq
+
+    return image_model
 
 
 def calibrateimage(config, verbose=True):
@@ -368,6 +549,19 @@ def calibrateimage(config, verbose=True):
     else:
         mylog.append("Skipping bias correction\n")
 
+    if "dark_decay" in caldir:
+        correct_dark_decay(ramp_model, caldir, mylog)
+    else:
+        ramp_model.meta.cal_step.dark_decay = "INCOMPLETE"
+
+    if config.get("correct_wfi18_transient", False):
+        # function marks the step "N/A" if not WFI18
+        correct_wfi18_transient(
+            ramp_model, mylog, mask_rows=config.get("WFI18_MASK_ROWS", False)
+        )
+    else:
+        ramp_model.meta.cal_step.wfi18_transient = "INCOMPLETE"
+
     # linearity correxction
     # ** right now applies the linearity to a group average, which isn't strictly correct **
     # ** will fix this in a future upgrade! **
@@ -379,18 +573,10 @@ def calibrateimage(config, verbose=True):
         attempt_corr=~rdq
         & pixel.SATURATED,  # don't flag saturated pixels as having a bad linearity correction
     )
-    if len(np.shape(dq_lin)) == 2:
-        rdq |= dq_lin[None, :, :]
-    else:
-        rdq |= dq_lin
+    pdq |= dq_lin
     del dq_lin  # we have everything we need
     mylog.append("Linearity correction complete\n")
-    # now data is in linearized DN, floating point
-
-    # subtract out dark current
-    # dcsub is the dark current that was subtracted --- data is updated in place
-    subtract_dark_current(data, rdq, pdq, caldir, meta, mylog)  # removed dcsub= assignment as it isn't used
-    mylog.append("Dark current subtracted")
+    ramp_model.data = data  # keep data and ramp_model.data in sync
 
     # IPC correction
     if "ipc4d" in caldir:
@@ -398,19 +584,18 @@ def calibrateimage(config, verbose=True):
     else:
         mylog.append("skipping IPC correction\n")
 
-    # ramp fitting
-    uopt = {"slope": 0.4, "gain": 1.8, "sigma_read": 6.5}
-    if "RAMP_OPT_PARS" in config:
-        uopt = config["RAMP_OPT_PARS"]
-    u_ = float(uopt["slope"]) / float(uopt["gain"]) / float(uopt["sigma_read"]) ** 2
-    meta["K"] = fitting.construct_weights(u_, meta, exclude_first=True)
-    mylog.append(f"\n\nRamp fit optimized for u = {u_:11.5E} s**-1\n")
-    mylog.append("weights = {}\n".format(meta["K"]))
-    if "JUMP_DETECT_PARS" in config:
-        meta["jump_detect_pars"] = config["JUMP_DETECT_PARS"]
-    slope, slope_err_read, slope_err_poisson = fitting.ramp_fit(
-        data, rdq, pdq, meta, caldir, mylog, exclude_first=True
-    )
+    # ramp-fit to a 2D rate ImageModel
+    image_model = do_ramp_fit(ramp_model, meta, config, caldir, mylog)
+
+    # subtract out dark current (updates image_model in place)
+    subtract_dark_current(image_model, caldir, mylog)
+    mylog.append("Dark current subtracted\n")
+
+    # unpack the rate image back into full-frame arrays for use downstream
+    slope = np.asarray(image_model.data, dtype=np.float32)
+    pdq = np.asarray(image_model.dq, dtype=np.uint32)
+    slope_err_read = np.sqrt(np.asarray(image_model.var_rnoise, dtype=np.float32))
+    slope_err_poisson = np.sqrt(np.asarray(image_model.var_poisson, dtype=np.float32))
 
     # apply flat field
     flat = flatutils.get_flat(caldir, meta, pdq)
@@ -470,9 +655,6 @@ def calibrateimage(config, verbose=True):
     # update the metadata
     # oututils.update_flags(im2, "gen_cal_image") # <-- this doesn't work with updated roman_datamodels,
     #                                                    but it isn't essential
-    if "cal_step" in im2["meta"]:
-        im2["meta"]["cal_step"]["wfi18_transient"] = "INCOMPLETE"
-        im2["meta"]["cal_step"]["dark_decay"] = "INCOMPLETE"
     oututils.add_in_provenance(im2, "gen_cal_image")
 
     # process information specific to this code
@@ -481,7 +663,7 @@ def calibrateimage(config, verbose=True):
         "medgain": medgain,
         "skyorder": skyorder,
         "skycoefs": skycoefs,
-        "ramp_opt_pars": uopt,
+        "ramp_opt_pars": meta["ramp_opt_pars"],
         "meta": meta,
         "weights": meta["K"],
         "config": config,

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -414,9 +414,11 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             readnoise = datamodels.ReadnoiseRefModel.create_from_model(fr["roman"])
         with asdf.open(caldir["gain"]) as fg:
             gain = datamodels.GainRefModel.create_from_model(fg["roman"])
-        # stcal's likelihood fitter treats the read-noise reference as
-        # CDS and divides it by sqrt(2) internally
-        # we multiply by sqrt(2) to convert to this convention.
+        # stcal's likelihood fitter treats the read-noise reference as CDS and
+        # divides it by sqrt(2) internally; Roman read noise is single-read, so
+        # we multiply by sqrt(2) here to compensate. This is a stopgap: the plan
+        # is to handle the convention in romancal (likely_fit), after which this
+        # line should be removed.
         readnoise.data = (np.sqrt(2) * readnoise.data).astype('f4')
         # exclude_first handling is not required here, since these pixels
         # are marked DO_NOT_USE in the initializationstep

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -418,11 +418,6 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
             readnoise = datamodels.ReadnoiseRefModel.create_from_model(fr["roman"])
         with asdf.open(caldir["gain"]) as fg:
             gain = datamodels.GainRefModel.create_from_model(fg["roman"])
-        # stcal's likelihood fitter treats the read-noise reference as CDS and
-        # divides it by sqrt(2) internally; Roman read noise is single-read, so
-        # we multiply by sqrt(2) here to compensate. This is a stopgap pending
-        # romancal PR https://github.com/spacetelescope/romancal/pull/2360
-        readnoise.data = (np.sqrt(2) * readnoise.data).astype("f4")
         # exclude_first handling is not required here, since these pixels
         # are marked DO_NOT_USE in the initializationstep
         image_model = ramp_fit_step.likely(

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -662,6 +662,12 @@ def calibrateimage(config, verbose=True):
         if x in im2 and hasattr(im2[x], "value"):
             im2[x] = im2[x].value
 
+    # carry through the romancal ramp-fit diagnostics
+    # dumo is slope-like, so flat-field it
+    if config.get("romancal_ramp_fit", False):
+        im2["dumo"] = (np.asarray(image_model.dumo) / flat[nb:-nb, nb:-nb]).astype(np.float16)
+        im2["chisq"] = np.asarray(image_model.chisq, dtype=np.float16)
+
     oututils.add_in_ref_data(im2, config["IN"], rdq, pdq)
 
     # update the metadata

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -31,12 +31,12 @@ from astropy import units as u
 from astropy.io import fits
 from roman_datamodels import datamodels
 from roman_datamodels.dqflags import group, pixel
-from romancal.datamodels.fileio import open_dataset
-from romancal.dq_init import dq_initialization
-from romancal.saturation import saturation
 from romancal.dark_current import dark_current_step
 from romancal.dark_decay.dark_decay import subtract_dark_decay
+from romancal.datamodels.fileio import open_dataset
+from romancal.dq_init import dq_initialization
 from romancal.ramp_fitting import ramp_fit_step
+from romancal.saturation import saturation
 from romancal.wfi18_transient.wfi18_transient import correct_anomaly
 from romanisim import image as rimage
 from romanisim import persistence as rip
@@ -422,7 +422,7 @@ def do_ramp_fit(ramp_model, meta, config, caldir, mylog):
         # divides it by sqrt(2) internally; Roman read noise is single-read, so
         # we multiply by sqrt(2) here to compensate. This is a stopgap pending
         # romancal PR https://github.com/spacetelescope/romancal/pull/2360
-        readnoise.data = (np.sqrt(2) * readnoise.data).astype('f4')
+        readnoise.data = (np.sqrt(2) * readnoise.data).astype("f4")
         # exclude_first handling is not required here, since these pixels
         # are marked DO_NOT_USE in the initializationstep
         image_model = ramp_fit_step.likely(

--- a/src/romanimpreprocess/utils/fitting.py
+++ b/src/romanimpreprocess/utils/fitting.py
@@ -338,7 +338,15 @@ def ramp_fit(data, rdq, pdq, meta, caldir, mylog, exclude_first=True):
 
     # propagate flags
     pdq2 = np.zeros_like(pdq)
-    pdq2 |= np.bitwise_or.reduce(np.where(~rdq & pixel.SATURATED, rdq, 0), axis=0)
+    dnu = np.uint32(pixel.DO_NOT_USE)
+    # OR per-group flags (e.g. JUMP_DET) from non-saturated groups into the
+    # pixel, but exclude DO_NOT_USE here: a single excluded resultant (e.g. the
+    # first, masked for exclude_first) does not mean the whole pixel is bad.
+    pdq2 |= np.bitwise_or.reduce(np.where(~rdq & pixel.SATURATED, rdq, 0), axis=0) & ~dnu
+    # do set DO_NOT_USE when _every_ group is flagged
+    pdq2 |= np.where(np.bitwise_and.reduce(rdq & pixel.DO_NOT_USE != 0, axis=0), dnu, 0).astype(
+        np.uint32
+    )
     # do not use pixels that saturated too fast
     pdq2 |= np.where(rdq[1 + start, :, :] & pixel.SATURATED != 0, pixel.DO_NOT_USE, 0).astype(np.uint32)
     # now fully flag the pixels that saturated

--- a/src/romanimpreprocess/utils/fitting.py
+++ b/src/romanimpreprocess/utils/fitting.py
@@ -344,9 +344,7 @@ def ramp_fit(data, rdq, pdq, meta, caldir, mylog, exclude_first=True):
     # first, masked for exclude_first) does not mean the whole pixel is bad.
     pdq2 |= np.bitwise_or.reduce(np.where(~rdq & pixel.SATURATED, rdq, 0), axis=0) & ~dnu
     # do set DO_NOT_USE when _every_ group is flagged
-    pdq2 |= np.where(np.bitwise_and.reduce(rdq & pixel.DO_NOT_USE != 0, axis=0), dnu, 0).astype(
-        np.uint32
-    )
+    pdq2 |= np.where(np.bitwise_and.reduce(rdq & pixel.DO_NOT_USE != 0, axis=0), dnu, 0).astype(np.uint32)
     # do not use pixels that saturated too fast
     pdq2 |= np.where(rdq[1 + start, :, :] & pixel.SATURATED != 0, pixel.DO_NOT_USE, 0).astype(np.uint32)
     # now fully flag the pixels that saturated

--- a/src/romanimpreprocess/utils/fitting.py
+++ b/src/romanimpreprocess/utils/fitting.py
@@ -192,11 +192,12 @@ def jump_detect(data, rdq, pdq, meta, caldir, mylog, exclude_first=True, truncat
     # get Poisson variance information
     # first coef (units: 1/time, since K has units of 1/time)
     # this would be 1/exposure time for simple CDS
+    # K[t] is the weight for resultant t
     coef = 0.0
-    for i in range(ngrp - start):
-        coef += K[i] ** 2 * meta["tau"][i + start]
-        for j in range(i):
-            coef += 2.0 * K[i] * K[j] * meta["tbar"][j + start]
+    for i in range(start, ngrp):
+        coef += K[i] ** 2 * meta["tau"][i]
+        for j in range(start, i):
+            coef += 2.0 * K[i] * K[j] * meta["tbar"][j]
     with asdf.open(caldir["gain"]) as f:
         dvardt = np.clip(slope / np.clip(f["roman"]["data"], 1e-4, 1e4), 0.0, None)
         # Poisson variance [DN^2] per second, clipped to be positive and avoid divbyzero

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -7,8 +7,10 @@ import os
 import asdf
 import numpy as np
 from astropy.io import fits
+from astropy.stats import mad_std
 from astropy.wcs import WCS
 from PIL import Image
+from roman_datamodels.dqflags import pixel
 from romanimpreprocess.from_sim import sim_to_isim
 from romanimpreprocess.L1_to_L2 import gen_cal_image, gen_noise_image
 from romanimpreprocess.utils import fpaplot, ipc_linearity, maskhandling, visualize
@@ -516,6 +518,15 @@ def test_run_all(tmp_path):
     print("\nwrite mask")
     maskhandling.PixelMask1.convert_file(c2["OUT"], c2["OUT"][:-5] + "_mask.fits")
 
+    # Also exercise the romancal likelihood ramp-fit path
+    # Turn on the WFI18 transient step, which is a no-op here because this is WFI04.
+    c_rc = c2 | {
+        "OUT": tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_{sca:d}_romancalfit.asdf",
+        "romancal_ramp_fit": True,
+        "correct_wfi18_transient": True,
+    }
+    gen_cal_image.calibrateimage(c_rc)
+
     ### TESTS ON THE OUTPUTS
 
     dtrim = 4
@@ -546,6 +557,9 @@ def test_run_all(tmp_path):
             if i == 2:
                 assert count > 10000 and count < 30000
         isGood = np.where(a["roman"]["dq"] == 0, 1, 0)
+        dq_local = np.asarray(a["roman"]["dq"])
+        err_local = np.asarray(a["roman"]["err"], dtype=np.float64)
+        vp_local = np.asarray(a["roman"]["var_poisson"], dtype=np.float64)
 
         # now pull out the data, in DN/s
         data_out = np.copy(a["roman"]["data"])
@@ -583,6 +597,47 @@ def test_run_all(tmp_path):
     # some quality checks on unmasked pixels
     assert np.count_nonzero(np.abs(x) > 100) < 50
     assert np.count_nonzero(np.logical_and(np.abs(x) > 20, expected_signal < 1)) < 50
+
+    # checks on the romancal likelihood ramp-fit output
+    with asdf.open(c_rc["OUT"]) as a_rc:
+        assert np.shape(a_rc["roman"]["data"]) == (4088, 4088)
+        assert "dumo" in a_rc["roman"]
+        assert "chisq" in a_rc["roman"]
+        isGood_rc = a_rc["roman"]["dq"] == 0
+        data_rc = np.asarray(a_rc["roman"]["data"])
+        assert np.all(np.isfinite(data_rc[isGood_rc]))
+        x_rc = np.where(isGood_rc, data_rc - expected_signal, 0.0)
+        assert np.count_nonzero(np.abs(x_rc) > 100) < 50
+
+        # The local and romancal-likelihood fitters use the same data, so on
+        # common good pixels they should report similar uncertainties, agree well
+        # within those uncertainties, and flag a similar number of cosmic rays.
+        dq_rc = np.asarray(a_rc["roman"]["dq"])
+        err_rc = np.asarray(a_rc["roman"]["err"], dtype=np.float64)
+        vp_rc = np.asarray(a_rc["roman"]["var_poisson"], dtype=np.float64)
+        common = isGood.astype(bool) & isGood_rc
+
+        # median uncertainties shouldn't change much. var_rnoise is not stored
+        # separately (recovered as err**2 - var_poisson); it differs more because
+        # the two fitters weight the resultants differently, so allow a factor.
+        for name, m_loc, m_rc, lo, hi in [
+            ("err", err_local, err_rc, 0.8, 1.2),
+            ("var_poisson", vp_local, vp_rc, 0.8, 1.2),
+            ("var_rnoise", err_local**2 - vp_local, err_rc**2 - vp_rc, 0.33, 3.0),
+        ]:
+            ratio = np.median(m_rc[common]) / np.median(m_loc[common])
+            print(f"uncertainty ratio rc/local {name:>11} = {ratio:.3f}")
+            assert lo < ratio < hi
+
+        # the two fits should agree well within their reported uncertainty
+        z = mad_std(((data_out - data_rc) / err_rc)[common])
+        # cosmic-ray flagging should be similar (also guards the read-noise
+        # sqrt(2) conversion -- without it the likelihood fitter over-flags)
+        jump_local = np.count_nonzero((dq_local & pixel.JUMP_DET) != 0)
+        jump_rc = np.count_nonzero((dq_rc & pixel.JUMP_DET) != 0)
+        print(f"mad_std((local-rc)/err)={z:.4f}, jump_local={jump_local}, jump_rc={jump_rc}")
+        assert z < 0.5
+        assert 100 < jump_rc < 2 * jump_local
 
     # check that we can convert the output to PDF
     visualize.visualize(

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -617,26 +617,22 @@ def test_run_all(tmp_path):
         vp_rc = np.asarray(a_rc["roman"]["var_poisson"], dtype=np.float64)
         common = isGood.astype(bool) & isGood_rc
 
-        # median uncertainties shouldn't change much. var_rnoise is not stored
-        # separately (recovered as err**2 - var_poisson); it differs more because
-        # the two fitters weight the resultants differently, so allow a factor.
-        for name, m_loc, m_rc, lo, hi in [
-            ("err", err_local, err_rc, 0.8, 1.2),
-            ("var_poisson", vp_local, vp_rc, 0.8, 1.2),
-            ("var_rnoise", err_local**2 - vp_local, err_rc**2 - vp_rc, 0.33, 3.0),
+        # median uncertainties shouldn't change by more than ~5%
+        for name, m_loc, m_rc in [
+            ("err", err_local, err_rc),
+            ("var_poisson", vp_local, vp_rc),
         ]:
             ratio = np.median(m_rc[common]) / np.median(m_loc[common])
             print(f"uncertainty ratio rc/local {name:>11} = {ratio:.3f}")
-            assert lo < ratio < hi
+            assert 0.95 < ratio < 1.05
 
         # the two fits should agree well within their reported uncertainty
         z = mad_std(((data_out - data_rc) / err_rc)[common])
-        # cosmic-ray flagging should be similar (also guards the read-noise
-        # sqrt(2) conversion -- without it the likelihood fitter over-flags)
+        # cosmic-ray flagging should be similar
         jump_local = np.count_nonzero((dq_local & pixel.JUMP_DET) != 0)
         jump_rc = np.count_nonzero((dq_rc & pixel.JUMP_DET) != 0)
         print(f"mad_std((local-rc)/err)={z:.4f}, jump_local={jump_local}, jump_rc={jump_rc}")
-        assert z < 0.5
+        assert z < 0.05
         assert 100 < jump_rc < 2 * jump_local
 
     # check that we can convert the output to PDF

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -320,6 +320,15 @@ def gencal(cstem, rng):
         }
     ).write_to(cstem + f"_saturation_{tag:s}_SCA{sca:02d}.asdf")
 
+    ### DARKDECAY
+
+    dectab = {}
+    for k in range(1, 19):
+        dectab[f"WFI{k:02d}"] = {"amplitude": 0.3 + 0.1 * np.cos(k), "time_constant": 20.0 + k}
+    asdf.AsdfFile({"roman": {"decay_table": dectab}}).write_to(
+        cstem + f"_darkdecay_{tag:s}_SCA{sca:02d}.asdf"
+    )
+
     return {}
 
 
@@ -495,6 +504,19 @@ def test_run_all(tmp_path):
         }
     )
 
+    # this will have darkdecay
+    sim_to_isim.run_config(
+        {
+            "IN": tmp_dir + f"/IN/Roman_Test_truth_{band:s}_{id}_{sca}.fits",
+            "OUT": tmp_dir + f"/OUT-L1/sim_L1withdd_{band:s}_{id:d}_{sca:d}.asdf",
+            "READS": these_reads,
+            "FITSOUT": True,
+            "CALDIR": caldir,
+            "CNORM": 1.0,
+            "SEED": 200,
+        }
+    )
+
     # copy this file into a place for WFI18 (so that we can test transient function)
     with asdf.open(tmp_dir + f"/OUT-L1/sim_L1_{band:s}_{id:d}_{sca:d}.asdf") as a:
         a["roman"]["meta"]["instrument"]["detector"] = "WFI18"
@@ -546,6 +568,14 @@ def test_run_all(tmp_path):
     c4 = c2 | {"correct_wfi18_transient": True, "EXCLUDE_FIRST": False}
     c4["OUT"] = tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_{sca:d}_noexcludefirst.asdf"
     gen_cal_image.calibrateimage(c4)
+
+    # this one tests dark decay
+    # right now not actually implemented -- this shows up as a change in the "sky"
+    c2d = c2.copy()
+    c2d["CALDIR"] = c2["CALDIR"] | {"dark_decay": tmp_dir + f"/roman_wfi_darkdecay_{tag:s}_SCA{sca:02d}.asdf"}
+    c2d["IN"] = tmp_dir + f"/OUT-L1/sim_L1withdd_{band:s}_{id:d}_{sca:d}.asdf"
+    c2d["OUT"] = tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_{sca:d}_withdecay.asdf"
+    gen_cal_image.calibrateimage(c2d)
 
     ### TESTS ON THE OUTPUTS
 
@@ -665,6 +695,17 @@ def test_run_all(tmp_path):
         assert np.percentile(diff, 90) < 0.01
         # make sure they are different!
         assert np.percentile(diff, 80) - np.percentile(diff, 20) > 1e-4
+
+    # checks on the darkdecay version
+    with asdf.open(c2["OUT"]) as a_orig, asdf.open(c2d["OUT"]) as a_new:
+        diff = a_new["roman"]["data"] - a_orig["roman"]["data"]
+        diff1d = np.median(diff, axis=1)
+        assert np.all(np.abs(diff1d) < 1.0e-4)
+
+        # sky goes "up" because we are correcting a downward slope
+        skydiff = a_new["processinfo"]["skycoefs"] - a_orig["processinfo"]["skycoefs"]
+        assert 0.004 < skydiff[0] < 0.007
+        assert np.all(np.abs(skydiff[1:]) < 0.0015)
 
     # check that we can convert the output to PDF
     visualize.visualize(

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -495,6 +495,17 @@ def test_run_all(tmp_path):
         }
     )
 
+    # copy this file into a place for WFI18 (so that we can test transient function)
+    with asdf.open(tmp_dir + f"/OUT-L1/sim_L1_{band:s}_{id:d}_{sca:d}.asdf") as a:
+        a["roman"]["meta"]["instrument"]["detector"] = "WFI18"
+        # this is just a toy example to exercise that the WFI18 correction is "on"
+        newdata = a["roman"]["data"][0, 4:-4, 4:-4].astype(np.float32)
+        rows = np.linspace(4, 4091, 4088)
+        rows += rows // 256 * 4  # insert a timing gap
+        newdata += (-80.0 * np.exp(-rows / 150.0) + 5.0 * np.exp(-rows / 1300.0)).astype(np.float32)[:, None]
+        a["roman"]["data"][0, 4:-4, 4:-4] = np.clip(newdata, 0, 65535)
+        a.write_to(tmp_dir + f"/OUT-L1/sim_L1_{band:s}_{id:d}_18.asdf")
+
     # Below here is stuff for Level 1-->2
 
     c2 = {
@@ -526,6 +537,15 @@ def test_run_all(tmp_path):
         "correct_wfi18_transient": True,
     }
     gen_cal_image.calibrateimage(c_rc)
+
+    # now do a test as if this were WFI18 to exercise the post-reset transient functionality
+    c2x = c2 | {"correct_wfi18_transient": True, "EXCLUDE_FIRST": False}
+    c2x["IN"] = tmp_dir + f"/OUT-L1/sim_L1_{band:s}_{id:d}_18.asdf"
+    c2x["OUT"] = tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_18_noexcludefirst.asdf"
+    gen_cal_image.calibrateimage(c2x)
+    c4 = c2 | {"correct_wfi18_transient": True, "EXCLUDE_FIRST": False}
+    c4["OUT"] = tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_{sca:d}_noexcludefirst.asdf"
+    gen_cal_image.calibrateimage(c4)
 
     ### TESTS ON THE OUTPUTS
 
@@ -634,6 +654,17 @@ def test_run_all(tmp_path):
         print(f"mad_std((local-rc)/err)={z:.4f}, jump_local={jump_local}, jump_rc={jump_rc}")
         assert z < 0.05
         assert 100 < jump_rc < 2 * jump_local
+
+    # checks on the WFI18 version
+    with asdf.open(c4["OUT"]) as a_notr, asdf.open(c2x["OUT"]) as a_withtr:
+        diff = a_withtr["roman"]["data"] - a_notr["roman"]["data"]
+        # the 10/20/80/90th percentile wthiout correction are -0.078/-0.049/+0.029/+0.031
+        assert np.percentile(diff, 10) > -0.01
+        assert np.percentile(diff, 20) > -0.005
+        assert np.percentile(diff, 80) < 0.005
+        assert np.percentile(diff, 90) < 0.01
+        # make sure they are different!
+        assert np.percentile(diff, 80) - np.percentile(diff, 20) > 1e-4
 
     # check that we can convert the output to PDF
     visualize.visualize(


### PR DESCRIPTION
This PR does a few things:
* adds the dark_decay step from romancal (optionally)
* adds the wfi18_transient step from romancal (optionally)
* uses the romancal dark subtraction step and moves the step to after ramp fitting, also deconvolving the dark reference file for IPC
* adds a mode that uses the likelihood-based ramp fitting (optionally)
* changes some steps to always look for parameters (like exclude_first) in the config rather than to look for them as separate arguments, the goal being to make it harder to use exclude_first in some places but not others
* uses the image model more consistently, rather than the collection of associated arrays (but still not pushed all the way through)
* fixes a bug in the ripp Poisson variance computation
* changes the collection of pixel dq flags from the linearity step, which were sometimes dropped before
* adds some associated tests

This work turned up one important romancal bug which is being fixed (stcal & romancal convention for read noise different by sqrt(2); https://github.com/spacetelescope/romancal/pull/2360).  There's a stopgap in this PR that makes things behave and tests pass until that is fixed.  My plan is to get that merged into romancal today or tomorrow and then to update this PR to remove the stopgap.

Following this PR, I still intend to add the romancal reference pixel correction, linearity correction and flat field correction as an option.

I've left in the preexisting ramp fitting.  The code would certainly be cleaner if we removed it.  The potential gotchas in the new code relative to the old code are:
- uniform weights come only through the float16 dumo field
- uniform weights are computed for zero source signal rather than the small source signal currently used

The ramp fitting is central enough that I left in both options until other folks can evaluate whether the replacement is adequate.

Some rough edges worth discussing:
- in the next round of this I will probably push the image model stuff all the way through.  One annoyance there is that the romancal image models after ramp fitting are 4088x4088 (trimming the border pixels), while ripping uses the full 4096x4096.  There are some gymnastics in the current code trying to work around this, doing things like extracting the inner 4088x4088 from the dark and embedding the inner 4088x4088 back in the 4096x4096 full frame.  My preference would be for us to decide that only the 4088x4088 are needed and I would update the code in some later PR to only use that post ramp fitting.
- the IPC correction is obviously a difference between romancal and ripp.  The code would be simpler if we delayed that as late as possible (and updated, e.g., the dark reference file accordingly).  I think technically IPC correction and flat fielding do not commute, and jump flagging and IPC correction also won't commute.  I doubt folks care strongly about the latter; I'm not sure about the former.  But I think it's time to return to the IPC discussion.