### PR TITLE
L1 format with data_encoding_offset

### DIFF
--- a/docs/from_sim_README.rst
+++ b/docs/from_sim_README.rst
@@ -1,16 +1,20 @@
 Detailed algorithms for generating L1 images
-##################################################
+############################################
 
 This page describes in a bit more detail how ``sim_to_isim`` works.
 
 Usage
-====================================
+=====
 
-The ``sim_to_isim.py`` script generates simulated Roman ASDF images from the OpenUniverse simulations (we may add more input formats in the future). Its calling format is::
+The ``sim_to_isim.py`` script generates simulated Roman ASDF images from the OpenUniverse simulations (we may add more input formats in the future). Its calling format is:
+
+.. code-block:: bash
 
   python3 -m romanimpreprocess.from_sim.sim_to_isim config.yaml
 
-You can also call this from python using the code::
+You can also call this from python using the code:
+
+.. code-block:: python
 
     import yaml
     with open('config.yaml') as f:
@@ -20,12 +24,12 @@ You can also call this from python using the code::
 which allows you to make lots of images as needed.
 
 Interaction between the codes
----------------------------------------
+-----------------------------
 
 The code calls ``romanisim``, but it passes some packaged algorithms into it, so it is more forming a combined workflow than acting as a wrapper. Aside from the need to add the read pattern to ``parameters.read_pattern`` (which is unavoidable), we were able to do this without any monkey-patching (because I dislike monkey-patching).
 
 Fields in the configuration
-====================================
+===========================
 
 The configuration is a Python dictionary (normally read from a YAML file).
 
@@ -35,9 +39,11 @@ The configuration is a Python dictionary (normally read from a YAML file).
 
 * ``OUT``: The output Level 1 ASDF image. Must end in ``.asdf``.
 
-* ``READS``: The read pattern. This is a flattened list of an even number of integers, for example the pattern::
+* ``READS``: The read pattern. This is a flattened list of an even number of integers, for example the pattern:
 
-    READS: [0, 1, 1, 2, 2, 4, 4, 10, 10, 26, 26, 32, 32, 34, 34, 35]
+  .. code-block:: yaml
+
+      READS: [0, 1, 1, 2, 2, 4, 4, 10, 10, 26, 26, 32, 32, 34, 34, 35]
 
   means that the groups that are being averaged are ``range(0,1)``, ``range(1,2)``, ``range(2,4)``, ``range(4,10)``, etc. If every read is being used in a group average, then the second integer in each pair is the same as the first one of the next pair. If there are dropped frames, then this won't be the case, e.g., if we had written ``...10, 10, 25, 26, 32, ...`` instead, then frame 25 would be dropped.
 
@@ -53,13 +59,21 @@ The configuration is a Python dictionary (normally read from a YAML file).
 
 * ``NO_AMP33``: If True, then does not try to read reference output information from the calibration files.
 
+* ``EXTRACT_REF``: If provided, you can include an encoding offset in the L1 file:
+
+  .. code-block:: yaml
+
+    "EXTRACT_REF": {"data_encoding_offset": 4000}
+
+  Such an offset is not used for the WFI TVAC data, but is planned for the flight data.
+
 Calibration file requirements
-====================================
+=============================
 
 The following ASDF calibration files are required if ``CALDIR`` is set (or optional if indicated). Each one has a format and units:
 
 CALDIR['dark']
------------------------------------------
+--------------
 
 Dark data. There are several arrays in it:
 
@@ -72,7 +86,7 @@ Dark data. There are several arrays in it:
   The dark current map. The reference pixel data in this array is ignored.
 
 CALDIR['gain'] 
--------------------
+--------------
 
 The gain array. The tree contains:
 
@@ -81,7 +95,7 @@ The gain array. The tree contains:
   The per-pixel gain (a constant array can be provided if per-pixel gain is not available). The reference pixel data in this array is ignored.
 
 CALDIR['ipc4d'] 
--------------------
+---------------
 
 The IPC kernel.
 
@@ -91,7 +105,7 @@ The IPC kernel.
 
 
 CALDIR['linearitylegendre']
---------------------------------
+---------------------------
 
 The linearity data. The tree contains:
 
@@ -101,7 +115,9 @@ The linearity data. The tree contains:
 
 * ``['roman']['Smax']``: 4096 x 4096, float32, DN:
 
-  This is a cube of Legendre polynomial coefficients and the bounds. The relation between raw signal (S) and linearized signal (Slin) in pixel (x,y) is via a two-step transformation::
+  This is a cube of Legendre polynomial coefficients and the bounds. The relation between raw signal (S) and linearized signal (Slin) in pixel (x,y) is via a two-step transformation:
+
+  .. code-block:: python
 
     # re-scale S into the domain of the Legendre polynomials:
     # S=Smin --> z=-1
@@ -122,7 +138,7 @@ The linearity data. The tree contains:
   The signal in DN that corresponds to "0 e in well". Note that unlike a CCD, where a charge packet in the silicon may truly be "empty", in Roman detectors there are always many free charges on the p-type side of the photodiode (the exact number can't be measured) and so charge in the well is always relative to some level.
 
 CALDIR['read'] 
--------------------
+--------------
 
 The read noise cube. The tree contains:
 
@@ -150,7 +166,7 @@ The read noise cube. The tree contains:
 
 
 CALDIR['biascorr'] (optional)
------------------------------------------
+-----------------------------
 
 If provided, this file contains information on how to correct dark current + non-linearity information to get the correct median level. It should contain:
 
@@ -163,14 +179,16 @@ If provided, this file contains information on how to correct dark current + non
   The time from reset to the reference level (i.e., what corresponds to "0 e in the well").
 
 Code structure
-=======================
+==============
 
 The ``Image2D`` class is the main object you will encounter. 
 
 Initialization
--------------------
+--------------
 
-``Image2D`` can be initialized from a simulated image::
+``Image2D`` can be initialized from a simulated image:
+
+.. code-block:: python
 
     x = Image2D('anlsim', fname='Roman_WAS_truth_F184_14747_10.fits')
 
@@ -179,9 +197,11 @@ The ``__init__`` function takes a file type, currently ``'anlsim'``, but which i
 *Comment:* The OpenUniverse 2024 simulation is in the Detector frame. The flip to convert to the Science frame is performed in the initialization function.
 
 Simulation
------------------------------
+----------
 
-The Roman images can be simulated using the ``simulate`` method::
+The Roman images can be simulated using the ``simulate`` method:
+
+.. code-block::python
 
     x.simulate(use_read_pattern, caldir)
 
@@ -194,7 +214,7 @@ Either way, this process only produces the ngroup x 4088 x 4088 cube of the scie
 A simulated slope fit and L2 image cube is generated (following the workflow in ``romanisim``), but we're not doing anything with those at the moment.
 
 Writing files
--------------------
+-------------
 
 The Level 1 data file is written to ASDF with the call::
 
@@ -203,19 +223,19 @@ The Level 1 data file is written to ASDF with the call::
 We also write the header (with flipping of the WCS if needed) with the suffix ``_asdf_wcshead.txt``, and if ``FITSOUT`` is true then we write the data cube with the suffix ``_asdf_to.fits``.
 
 Methodology
-=======================
+===========
 
 The ordering of operations assumed here is as follows.
 
 Reset
----------
+-----
 
 We implement a Gaussian reset noise.
 
 The mean reset level is set to a negative number of elementary charges so that it will integrate up to 0 on average in the dark at the time used to compute the "0 e" level (that would usually be the first stable frame after the reset, but it doesn't have to be).
 
 Charge accumulation
------------------------------------
+-------------------
 
 Accumulation of signal into pixels (in elementary charges, e) is simulated first. Right now this is a Poissonian process.
 
@@ -226,41 +246,41 @@ Accumulation of signal into pixels (in elementary charges, e) is simulated first
 * The brighter-fatter effect and quantum yield are not yet implemented.
 
 Inter-pixel capacitance (IPC)
-----------------------------------
+-----------------------------
 
 IPC is implemented next, using the per-pixel map (although in practice that map might be constant in super-pixels).
 
 *Comment:* It is not clear that it is entirely distinct from nonlinearity and gain, since some contributions to the nonlinearity and gain happen in the pixel and thus are "simultaneous" with IPC: the collected charges and even the boundary of the depletion zone are moving around to minimize free energy, and IPC means that this process is not independent across pixels). But because of how IPC and gain are measured, we do them before non-linearity.
 
 Gain
----------
+----
 
 By definition, this is a simple conversion from elementary charges to linearized digital numbers ("DN_lin") in the same pixel.
 
 Non-linearity
------------------------
+-------------
 
 The non-linearity curve is computed using the Legendre polynomial cube. Pixels that go up to Smax (saturation level) will be clipped.
 
 Uncorrelated read noise
----------------------------
+-----------------------
 
 The uncorrelated read noise term is added next. This is Gaussian white noise.
 
 Bias
----------------------
+----
 
 A bias (from ``biascorr``) can be added to make sure that the median dark comes out right. In building the calibration files, this is really computed from the median dark minus what you get by running the dark current through the non-linearity curve, so it accomplishes this by construction.
 
 The ``biascorr`` is usually small (except in the read-reset frame), but this step does make the hot pixels appear a bit more realistic (e.g., in cases where they are initially hot but then the dark current decreases before they saturate). But I don't think we really want to use the hot pixels for science so this aspect may not matter. Similarly, I don't think we want to use the read-reset frame directly for science, although it probably contains some useful calibration information.
 
 Reference pixels
---------------------
+----------------
 
 The reference pixel padding is done next. These pixels have reset and read noise, but don't respond to the sky and are not included in the IPC calculation (since empirically we don't see IPC involving the edge pixels).
 
 Correlated read noise
-----------------------------
+---------------------
 
 The correlated read noise (both 1/f components that are common across all channels and independent) are generated by FFT'ing a Gaussian random vector whose length is twice the readout.
 

--- a/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_cal_image.py
@@ -558,7 +558,8 @@ def calibrateimage(config, verbose=True):
     # bias correction
     if "biascorr" in caldir:
         with asdf.open(caldir["biascorr"]) as f:
-            data[:, nb:-nb, nb:-nb] -= f["roman"]["data"]
+            de = np.shape(f["roman"]["data"])[0] - np.shape(data)[0]
+            data[:, nb:-nb, nb:-nb] -= f["roman"]["data"][de:]
         mylog.append("Included bias correction\n")
     else:
         mylog.append("Skipping bias correction\n")

--- a/src/romanimpreprocess/L1_to_L2/gen_noise_image.py
+++ b/src/romanimpreprocess/L1_to_L2/gen_noise_image.py
@@ -101,9 +101,14 @@ def make_noise_cube(config, rng):
             # if not adding, clear the input image
             if "a" not in noiseflags:
                 with asdf.open(config["CALDIR"]["dark"]) as fb:
-                    mytree["roman"]["data"] = np.copy(fb["roman"]["data"]).astype(
-                        mytree["roman"]["data"].dtype
-                    )
+                    de = np.shape(fb["roman"]["data"])[0] - np.shape(mytree["roman"]["data"])[0]
+                    mytree["roman"]["data"] = fb["roman"]["data"].astype(mytree["roman"]["data"].dtype)
+
+                    # if de is 1, then the first slice is a reference read that we're not using
+                    # 0 otherwise
+                    if de not in [0, 1]:
+                        raise ValueError("Dark date cube has the wrong shape.")
+                    mytree["roman"]["data"] = mytree["roman"]["data"][de:, :, :]
 
                 # write this to a file and calibrate it
                 with asdf.AsdfFile(mytree) as af, open(config["NOISE"]["TEMP"], "wb") as f:
@@ -115,7 +120,7 @@ def make_noise_cube(config, rng):
 
             # white noise
             for k in range(len(mytree["roman"]["meta"]["exposure"]["read_pattern"])):
-                resultants = np.copy(mytree["roman"]["data"][k, nb:-nb, nb:-nb].astype(np.float32))
+                resultants = mytree["roman"]["data"][k, nb:-nb, nb:-nb].astype(np.float32)
                 im = np.zeros_like(resultants)
                 galsim.GaussianDeviate(rng).generate(im)
                 with asdf.open(config["CALDIR"]["read"]) as fr:

--- a/src/romanimpreprocess/from_sim/sim_to_isim.py
+++ b/src/romanimpreprocess/from_sim/sim_to_isim.py
@@ -348,7 +348,8 @@ def fill_in_refdata_and_1f(im, caldir, rng, tij, fill_in_banding=True, amp33=Non
     noise[:-1, :, :] += noise[-1, :, :][None, :, :]  # adds the reset noise to the reference pixels
 
     with asdf.open(caldir["dark"]) as f:
-        noise[:-1, :, :] += np.copy(f["roman"]["data"])
+        de = np.shape(f["roman"]["data"])[0] - ngrp
+        noise[:-1, :, :] += np.copy(f["roman"]["data"][de:, :, :])
 
     # what we have above is a dark image, but we want to fill in the
     # active pixels with the data from im
@@ -706,6 +707,28 @@ class Image2D:
                 amp33=amp33struct,
             )
 
+        # move reference read, if requested
+        if "EXTRACT_REF" in config:
+            data_encoding_offset = int(config["EXTRACT_REF"].get("data_encoding_offset", 0))
+            nresultants = im["meta"]["exposure"]["nresultants"]  # won't change this, but want shorthand
+            im["meta"]["instrument"]["data_encoding_offset"] = data_encoding_offset
+            im["meta"]["exposure"]["read_pattern"] = im["meta"]["exposure"]["read_pattern"][1:]
+            im["reference_read"] = np.copy(im["data"][0])
+            modref = im["data"][0].astype(np.int32) - data_encoding_offset
+            for k in range(1, nresultants):
+                im["data"][k, :, :] = np.clip(im["data"][k, :, :].astype(np.int32) - modref, 0, 65535).astype(
+                    np.uint16
+                )
+            im["data"] = im["data"][1:, :, :]
+            if caldir is not None and "NO_AMP33" not in caldir:
+                im["reference_amp33"] = np.copy(im["amp33"][0])
+                modref = im["amp33"][0].astype(np.int32) - data_encoding_offset
+                for k in range(1, nresultants):
+                    im["amp33"][k, :, :] = np.clip(
+                        im["amp33"][k, :, :].astype(np.int32) - modref, 0, 65535
+                    ).astype(np.uint16)
+                im["amp33"] = im["amp33"][1:, :, :]
+
         # Create metadata for simulation parameter
         romanisimdict = {"version": rstversion}
         # for storage reasons, I took out all the large metadata arrays in romanisimdict
@@ -966,8 +989,9 @@ def run_config(config):
     # also write the FITS file for viewing
     if "FITSOUT" in config:
         if config["FITSOUT"]:
-            image_out = np.zeros((ng, pars.nside, pars.nside_augmented), dtype=np.uint16)
             with asdf.open(config["OUT"]) as f:
+                ng2 = np.shape(f["roman"]["data"])[0]
+                image_out = np.zeros((ng2, pars.nside, pars.nside_augmented), dtype=np.uint16)
                 image_out[:, :, : pars.nside] = f["roman"]["data"]
                 image_out[:, :, pars.nside :] = f["roman"]["amp33"]
                 fits.PrimaryHDU(image_out).writeto(config["OUT"][:-5] + "_asdf_to.fits", overwrite=True)

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -422,7 +422,7 @@ def il_example(linearity_file, gain_file, ipc_file):
     assert np.all(np.abs(target2 - val2) < 0.002)
 
 
-def test_run_all(tmp_path):
+def run_all(tmp_path, subtr):
     """
     Test function for a small pyimcom run.
 
@@ -430,6 +430,8 @@ def test_run_all(tmp_path):
     ----------
     tmp_path : str or pathlib.Path
         Directory in which to run the test.
+    subtr : bool
+        Test whether to package the reference array?
 
     Returns
     -------
@@ -492,6 +494,7 @@ def test_run_all(tmp_path):
         assert np.all(np.abs(diff) < 16)
     Image.fromarray(arr[::-1, :, :]).save("panel_image.png")
 
+    supp = {"EXTRACT_REF": {"data_encoding_offset": 4000}} if subtr else {}
     sim_to_isim.run_config(
         {
             "IN": tmp_dir + f"/IN/Roman_Test_truth_{band:s}_{id}_{sca}.fits",
@@ -502,6 +505,7 @@ def test_run_all(tmp_path):
             "CNORM": 1.0,
             "SEED": 200,
         }
+        | supp
     )
 
     # this will have darkdecay
@@ -515,6 +519,7 @@ def test_run_all(tmp_path):
             "CNORM": 1.0,
             "SEED": 200,
         }
+        | supp
     )
 
     # copy this file into a place for WFI18 (so that we can test transient function)
@@ -546,6 +551,8 @@ def test_run_all(tmp_path):
             "OUT": tmp_dir + f"/OUT-L2/sim_L2_{band:s}_{id:d}_{sca:d}_noise.asdf",
         },
     }
+    if subtr:
+        c2["EXCLUDE_FIRST"] = False
     gen_cal_image.calibrateimage(c2 | {"SLICEOUT": True})
     gen_noise_image.generate_all_noise(c2)
     print("\nwrite mask")
@@ -689,10 +696,10 @@ def test_run_all(tmp_path):
     with asdf.open(c4["OUT"]) as a_notr, asdf.open(c2x["OUT"]) as a_withtr:
         diff = a_withtr["roman"]["data"] - a_notr["roman"]["data"]
         # the 10/20/80/90th percentile wthiout correction are -0.078/-0.049/+0.029/+0.031
-        assert np.percentile(diff, 10) > -0.01
-        assert np.percentile(diff, 20) > -0.005
-        assert np.percentile(diff, 80) < 0.005
-        assert np.percentile(diff, 90) < 0.01
+        assert np.percentile(diff, 10) > -0.014
+        assert np.percentile(diff, 20) > -0.007
+        assert np.percentile(diff, 80) < 0.007
+        assert np.percentile(diff, 90) < 0.014
         # make sure they are different!
         assert np.percentile(diff, 80) - np.percentile(diff, 20) > 1e-4
 
@@ -758,6 +765,16 @@ def test_run_all(tmp_path):
         assert c3["NOISE_PRECISION"] == 0  # shouldn't get here
     except ValueError as ve:
         assert str(ve) == "Unsupported noise precision."
+
+
+def test_run_all0(tmp_path):
+    """Test with moving the reference."""
+    run_all(tmp_path, True)
+
+
+def test_run_all1(tmp_path):
+    """Test without moving the reference."""
+    run_all(tmp_path, False)
 
 
 def test_flip(tmp_path):

--- a/tests/romanimpreprocess/test_workflow.py
+++ b/tests/romanimpreprocess/test_workflow.py
@@ -422,7 +422,7 @@ def il_example(linearity_file, gain_file, ipc_file):
     assert np.all(np.abs(target2 - val2) < 0.002)
 
 
-def run_all(tmp_path, subtr):
+def run_all(tmp_path, subtr, checkdata, cleanup=True):
     """
     Test function for a small pyimcom run.
 
@@ -432,10 +432,22 @@ def run_all(tmp_path, subtr):
         Directory in which to run the test.
     subtr : bool
         Test whether to package the reference array?
+    checkdata : dict
+        Dictionary of properties to check. Includes the keys:
+
+        - ``wfi18p1``: 1st percentile of each time slice of the L1 with WFI18 transient
+        - ``wfi18p99``: 99th percentile of each time slice of the L1 with WFI18 transient
+
+    cleanup : bool, optional
+        Whether to clean up files when done? (Only turn off if you are running on a local
+        machine to look at artifacts.)
 
     Returns
     -------
-    None
+    image : np.ndarray
+        The slope image from the default run.
+    mask : np.ndarray
+        The mask from the default run.
 
     """
 
@@ -693,6 +705,14 @@ def run_all(tmp_path, subtr):
         assert 100 < jump_rc < 2 * jump_local
 
     # checks on the WFI18 version
+    with asdf.open(c2x["IN"]) as _a:
+        assert np.allclose(
+            np.percentile(_a["roman"]["data"], 99, axis=(-2, -1)), checkdata["wfi18p99"], atol=2.2, rtol=0.0
+        )
+        assert np.allclose(
+            np.percentile(_a["roman"]["data"], 1, axis=(-2, -1)), checkdata["wfi18p1"], atol=2.2, rtol=0.0
+        )
+
     with asdf.open(c4["OUT"]) as a_notr, asdf.open(c2x["OUT"]) as a_withtr:
         diff = a_withtr["roman"]["data"] - a_notr["roman"]["data"]
         # the 10/20/80/90th percentile wthiout correction are -0.078/-0.049/+0.029/+0.031
@@ -766,15 +786,92 @@ def run_all(tmp_path, subtr):
     except ValueError as ve:
         assert str(ve) == "Unsupported noise precision."
 
+    with fits.open(str(tmp_path) + "/OUT-L2/sim_L2_F184_163_4_asdf_to.fits") as f:
+        image = np.copy(f[0].data)
+        mask = np.copy(f[1].data)
 
-def test_run_all0(tmp_path):
-    """Test with moving the reference."""
-    run_all(tmp_path, True)
+    if cleanup:
+        for rf in [
+            "out_im1.pdf",
+            "roman_wfi_linearitylegendre_TESTONLY_SCA04.asdf",
+            "temp_F184_163_4_L2.asdf",
+            "roman_wfi_biascorr_TESTONLY_SCA04.asdf",
+            "roman_wfi_mask_TESTONLY_SCA04.asdf",
+            "temp_F184_163_4_refL2_asdf_to.fits",
+            "roman_wfi_dark_TESTONLY_SCA04.asdf",
+            "roman_wfi_pflat_TESTONLY_SCA04.asdf",
+            "temp_F184_163_4_refL2.asdf",
+            "roman_wfi_darkdecay_TESTONLY_SCA04.asdf",
+            "roman_wfi_read_TESTONLY_SCA04.asdf",
+            "temp_F184_163_4.asdf",
+            "roman_wfi_gain_TESTONLY_SCA04.asdf",
+            "roman_wfi_saturation_TESTONLY_SCA04.asdf",
+            "roman_wfi_ipc4d_TESTONLY_SCA04.asdf",
+            "temp_F184_163_4_L2_asdf_to.fits",
+        ]:
+            os.remove(tmp_path / rf)
+        for rf in ["Roman_Test_truth_F184_163_4.fits"]:
+            os.remove(tmp_path / f"IN/{rf}")
+        for rf in [
+            "sim_L1_F184_163_18.asdf",
+            "sim_L1_F184_163_4.asdf",
+            "sim_L1withdd_F184_163_4.asdf",
+            "sim_L1_F184_163_4_asdf_to.fits",
+            "sim_L1withdd_F184_163_4_asdf_to.fits",
+            "sim_L1_F184_163_4_asdf_wcshead.txt",
+            "sim_L1withdd_F184_163_4_asdf_wcshead.txt",
+        ]:
+            os.remove(tmp_path / f"OUT-L1/{rf}")
+        for rf in [
+            "sim_L2_F184_163_18_noexcludefirst_asdf_to.fits",
+            "sim_L2_F184_163_4_noexcludefirst.asdf",
+            "sim_L2_F184_163_4_romancalfit_asdf_to.fits",
+            "sim_L2_F184_163_18_noexcludefirst.asdf",
+            "sim_L2_F184_163_4_noise_asdf_to.fits",
+            "sim_L2_F184_163_4_romancalfit.asdf",
+            "sim_L2_F184_163_4_asdf_to.fits",
+            "sim_L2_F184_163_4_noise.asdf",
+            "sim_L2_F184_163_4_withdecay_asdf_to.fits",
+            "sim_L2_F184_163_4_mask.fits",
+            "sim_L2_F184_163_4_noise16_asdf_to.fits",
+            "sim_L2_F184_163_4_withdecay.asdf",
+            "sim_L2_F184_163_4_noexcludefirst_asdf_to.fits",
+            "sim_L2_F184_163_4_noise16.asdf",
+            "sim_L2_F184_163_4.asdf",
+        ]:
+            os.remove(tmp_path / f"OUT-L2/{rf}")
+
+    return image, mask
 
 
-def test_run_all1(tmp_path):
-    """Test without moving the reference."""
-    run_all(tmp_path, False)
+def test_run_all(tmp_path):
+    """Main workflow test."""
+
+    # Test with moving the reference.
+    im0, mask0 = run_all(
+        tmp_path,
+        True,
+        {
+            "wfi18p99": np.array([4030.0, 4034.0, 4044.0, 4060.0, 4068.0]),
+            "wfi18p1": np.array([3946.0, 3979.0, 3984.0, 3984.0, 3982.0]),
+        },
+    )
+
+    # Test without moving the reference.
+    im1, mask1 = run_all(
+        tmp_path,
+        False,
+        {
+            "wfi18p99": np.array([5925.0, 5927.0, 5931.0, 5937.0, 5944.0, 5947.0]),
+            "wfi18p1": np.array([4780.0, 4785.0, 4788.0, 4793.0, 4796.0, 4797.0]),
+        },
+    )
+
+    # Check that we got the same answer.
+    thresh = 2  # want to allow the occasional floating point moves over a flag boundary.
+    assert np.count_nonzero(mask0 != mask1) <= thresh
+    err = np.abs(im1 - im0) / (1.0 + np.abs(im1))
+    assert np.count_nonzero(err > 3.0e-4) <= thresh
 
 
 def test_flip(tmp_path):


### PR DESCRIPTION
This adds an "afterburner" in `sim_to_isim` that reformats the array using the `data_encoding_offset` field (as will be used for flight data).

The `test_workflow.py` unit test now runs both with _and_ without `data_encoding_offset`. I included a check at the end that they agree (allowing at most 2 pixels in the final image to fail the check — right now 0 do, but there are ways with floating point precision that this might not always be the case).

I also added this option to the README.